### PR TITLE
Avoid using print in device destructor.

### DIFF
--- a/source/Irrlicht/CIrrDeviceSDL.cpp
+++ b/source/Irrlicht/CIrrDeviceSDL.cpp
@@ -231,7 +231,6 @@ CIrrDeviceSDL::~CIrrDeviceSDL()
 	if (--SDLDeviceInstances == 0)
 	{
 		SDL_Quit();
-		os::Printer::log("Quit SDL", ELL_INFORMATION);
 	}
 }
 


### PR DESCRIPTION
It's because irrlicht tries to send event to eventhandler when doing print and that eventhandler function may be already destroyed.