### PR TITLE
Fixed textinput crash.

### DIFF
--- a/include/IEventReceiver.h
+++ b/include/IEventReceiver.h
@@ -600,7 +600,7 @@ struct SEvent
 	struct SSDLTextEvent
 	{
 		ESDL_EVENT_TYPE Type;
-		c8 Text[32];
+		const char* Text;
 		s32 Start; // SDL_EVENT_TEXT_EDITING usage
 		s32 Length; // SDL_EVENT_TEXT_EDITING usage
 	};

--- a/source/Irrlicht/CGUIEditBox.cpp
+++ b/source/Irrlicht/CGUIEditBox.cpp
@@ -258,16 +258,20 @@ bool CGUIEditBox::OnEvent(const SEvent& event)
 		case EET_SDL_TEXT_EVENT:
 			if (event.SDLTextEvent.Type == irr::ESDLET_TEXTINPUT)
 			{
-				wchar_t* text = new wchar_t[32]();
-				irr::core::utf8ToWchar(event.SDLTextEvent.Text, text, 32 * sizeof(wchar_t));
-				size_t textLength = wcslen(text);
-
-				for (size_t i = 0; i < textLength; i++)
+				if (event.SDLTextEvent.Text)
 				{
-					inputChar(text[i]);
-				}
+					size_t len = strlen(event.SDLTextEvent.Text) + 1;
+					wchar_t* text = new wchar_t[len]();
+					irr::core::utf8ToWchar(event.SDLTextEvent.Text, text, len * sizeof(wchar_t));
+					size_t textLength = wcslen(text);
 
-				delete[] text;
+					for (size_t i = 0; i < textLength; i++)
+					{
+						inputChar(text[i]);
+					}
+
+					delete[] text;
+				}
 
 				return true;
 			}

--- a/source/Irrlicht/CIrrDeviceSDL.cpp
+++ b/source/Irrlicht/CIrrDeviceSDL.cpp
@@ -1112,10 +1112,7 @@ bool CIrrDeviceSDL::run()
 			{
 				irrevent.EventType = irr::EET_SDL_TEXT_EVENT;
 				irrevent.SDLTextEvent.Type = irr::ESDLET_TEXTEDITING;
-				const size_t size = sizeof(irrevent.SDLTextEvent.Text);
-				const size_t other_size = sizeof(SDL_event.edit.text);
-				static_assert(sizeof(size) == sizeof(other_size), "Wrong size");
-				memcpy(irrevent.SDLTextEvent.Text, SDL_event.edit.text, size);
+				irrevent.SDLTextEvent.Text = SDL_event.edit.text;
 				irrevent.SDLTextEvent.Start = SDL_event.edit.start;
 				irrevent.SDLTextEvent.Length = SDL_event.edit.length;
 				postEventFromUser(irrevent);
@@ -1126,10 +1123,7 @@ bool CIrrDeviceSDL::run()
 			{
 				irrevent.EventType = irr::EET_SDL_TEXT_EVENT;
 				irrevent.SDLTextEvent.Type = irr::ESDLET_TEXTINPUT;
-				const size_t size = sizeof(irrevent.SDLTextEvent.Text);
-				const size_t other_size = sizeof(SDL_event.text.text);
-				static_assert(sizeof(size) == sizeof(other_size), "Wrong size");
-				memcpy(irrevent.SDLTextEvent.Text, SDL_event.text.text, size);
+				irrevent.SDLTextEvent.Text = SDL_event.text.text;
 				irrevent.SDLTextEvent.Start = 0;
 				irrevent.SDLTextEvent.Length = 0;
 				postEventFromUser(irrevent);


### PR DESCRIPTION
SDL3 text input is not fixed-size anymore.