### PR TITLE
Remove application events from SDL driver.

### DIFF
--- a/source/Irrlicht/CIrrDeviceSDL.cpp
+++ b/source/Irrlicht/CIrrDeviceSDL.cpp
@@ -667,42 +667,6 @@ bool CIrrDeviceSDL::run()
 
 		switch (SDL_event.type)
 		{
-		case SDL_EVENT_WILL_ENTER_BACKGROUND:
-			irrevent.EventType = irr::EET_APPLICATION_EVENT;
-			irrevent.ApplicationEvent.EventType = irr::EAET_WILL_PAUSE;
-			postEventFromUser(irrevent);
-			break;
-
-		case SDL_EVENT_DID_ENTER_BACKGROUND:
-			irrevent.EventType = irr::EET_APPLICATION_EVENT;
-			irrevent.ApplicationEvent.EventType = irr::EAET_DID_PAUSE;
-			postEventFromUser(irrevent);
-			break;
-
-		case SDL_EVENT_WILL_ENTER_FOREGROUND:
-			irrevent.EventType = irr::EET_APPLICATION_EVENT;
-			irrevent.ApplicationEvent.EventType = irr::EAET_WILL_RESUME;
-			postEventFromUser(irrevent);
-			break;
-
-		case SDL_EVENT_DID_ENTER_FOREGROUND:
-			irrevent.EventType = irr::EET_APPLICATION_EVENT;
-			irrevent.ApplicationEvent.EventType = irr::EAET_DID_RESUME;
-			postEventFromUser(irrevent);
-			break;
-
-		case SDL_EVENT_LOW_MEMORY:
-			irrevent.EventType = irr::EET_APPLICATION_EVENT;
-			irrevent.ApplicationEvent.EventType = irr::EAET_MEMORY_WARNING;
-			postEventFromUser(irrevent);
-			break;
-
-		case SDL_EVENT_TERMINATING:
-			irrevent.EventType = irr::EET_APPLICATION_EVENT;
-			irrevent.ApplicationEvent.EventType = irr::EAET_WILL_TERMINATE;
-			postEventFromUser(irrevent);
-			break;
-
 		// From https://github.com/libsdl-org/SDL/blob/main/docs/README-android.md
 		// However, there's a chance (on older hardware, or on systems under heavy load),
 		// where the GL context can not be restored. In that case you have to


### PR DESCRIPTION
Related to
https://github.com/MultiCraft/MultiCraft/commit/17dd27a892d5cb84fe96daf0ade96594d3d26023

In SDL3 we don't get application events when using SDL_PollEvent() and it needs callback function with SDL_AddEventWatch() instead that can receive them in different thread.