### PR TITLE
Add missing render device lost event

### DIFF
--- a/source/Irrlicht/CIrrDeviceSDL.cpp
+++ b/source/Irrlicht/CIrrDeviceSDL.cpp
@@ -673,6 +673,7 @@ bool CIrrDeviceSDL::run()
 		// listen for a specific message (SDL_EVENT_RENDER_DEVICE_RESET) and restore
 		// your textures manually or quit the app.
 		case SDL_EVENT_RENDER_DEVICE_RESET:
+		case SDL_EVENT_RENDER_DEVICE_LOST:
 			Close = true;
 			return false;
 


### PR DESCRIPTION
SDL2 had SDL_RENDER_DEVICE_RESET but SDL3 has both SDL_EVENT_RENDER_DEVICE_RESET and SDL_EVENT_RENDER_DEVICE_LOST.