### PR TITLE
CAnimatedMeshSceneNode: Call getBoundingBox() after getMesh()

### DIFF
--- a/source/Irrlicht/CAnimatedMeshSceneNode.cpp
+++ b/source/Irrlicht/CAnimatedMeshSceneNode.cpp
@@ -830,9 +830,9 @@ void CAnimatedMeshSceneNode::setMesh(IAnimatedMesh* mesh, bool copyMeshMaterials
 	}
 
 	// get materials and bounding box
+	IMesh* m = Mesh->getMesh(0,0);
 	Box = Mesh->getBoundingBox();
 
-	IMesh* m = Mesh->getMesh(0,0);
 	if (m && copyMeshMaterials)
 	{
 		Materials.clear();


### PR DESCRIPTION
This fixes the bug where we had to add an offscreen `model[]` to work around a bug where models were being clipped.

`getMesh()` calls some animation setting code that changes the bounding box, so we want to set the bounding box to the updated one.

`CAnimatedMeshSceneNode` is used in-game as well so I was concerned about introducing bugs, but from what I can tell nothing `getMesh()` calls reads the `Box` variable anyway.  I also haven't noticed anything wrong in my brief testing in-game.

<sub>I used a LLM to look at Irrlicht to try and find the root cause since I was procrastinating on this task and wanted to see how well LLMs worked, but I feel like I should have just done this myself since I'd already figured out that calling `setMesh` twice "fixed" it.</sub>